### PR TITLE
 doc: translate dom-elements

### DIFF
--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -14,34 +14,27 @@ redirect_from:
   - "tips/dangerously-set-inner-html.html"
 ---
 
-React implements a browser-independent DOM system for performance and cross-browser compatibility. We took the opportunity to clean up a few rough edges in browser DOM implementations.
 React 實踐了一個具有效能且跨瀏覽器兼容的 DOM system。並在實踐的過程中，優化 DOM 美中不足之處。
 
-In React, all DOM properties and attributes (including event handlers) should be camelCased. For example, the HTML attribute `tabindex` corresponds to the attribute `tabIndex` in React. The exception is `aria-*` and `data-*` attributes, which should be lowercased. For example, you can keep `aria-label` as `aria-label`.
-在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 應該保持 `aria-label` 原樣。
+在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 保持原樣即可。
 
 ## Attributes 相異之處 {#differences-in-attributes}
 
-There are a number of attributes that work differently between React and HTML:
 有些 attribute 在 React 和 HTML 之間運作的方式略為不同：
 
 ### checked {#checked}
 
-The `checked` attribute is supported by `<input>` components of type `checkbox` or `radio`. You can use it to set whether the component is checked. This is useful for building controlled components. `defaultChecked` is the uncontrolled equivalent, which sets whether the component is checked when it is first mounted.
-當 `<input>` 的 type 是 `checkbox` 或是 `radio` 時，可以使用 `checked` 這個 attribute 來設置 component 是否被選取。這在建立 controlled component 時很有幫助。`defaultChecked` 則是被使用在 uncontrolled component，當初始 mount 後設置 component 是否被選取。
+當 `<input>` 的 type 是 `checkbox` 或是 `radio` 時，可以使用 `checked` 這個 attribute 來設置 component 是否被選取。這對建立 controlled component 很有幫助。`defaultChecked` 則是使用在 uncontrolled component，當初始 mount 後設置 component 是否被選取。
 
 ### className {#classname}
 
-To specify a CSS class, use the `className` attribute. This applies to all regular DOM and SVG elements like `<div>`, `<a>`, and others.
 要指定一個 CSS class 時，使用 `className` attribute。這在所有常規的 DOM 和 SVG element 像是 `<div>`、`<a>` 還有其他的都能適用。
 
-If you use React with Web Components (which is uncommon), use the `class` attribute instead.
-如果你在 React 裡使用 Web Components（這不是常見的狀況），則使用 `class`。
+如果你在 React 裡使用 Web Component（這不是常見的狀況），則使用 `class`。
 
 ### dangerouslySetInnerHTML {#dangerouslysetinnerhtml}
 
-`dangerouslySetInnerHTML` is React's replacement for using `innerHTML` in the browser DOM. In general, setting HTML from code is risky because it's easy to inadvertently expose your users to a [cross-site scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) attack. So, you can set HTML directly from React, but you have to type out `dangerouslySetInnerHTML` and pass an object with a `__html` key, to remind yourself that it's dangerous. For example:
-`dangerouslySetInnerHTML` 是 React 用來替代 DOM 的 `innerHTML`。普遍來說，從程式碼中注入 HTML 是個冒險的行為，很輕易地你就會讓使用者暴露在 [cross-site scripting (XSS)](https://zh.wikipedia.org/wiki/跨網站指令碼) 風險之下。所以，在 React 裡你還是可以直接注入 HTML，但是你必須使用 `dangerouslySetInnerHTML`，然後傳入一個有 `__html` 為 key 的物件，藉此來提醒你自己這樣做具有風險。例子如下：
+`dangerouslySetInnerHTML` 是 React 用來替代 DOM 的 `innerHTML`。普遍來說，從程式碼中注入 HTML 是個冒險的行為，你會很輕易地讓使用者暴露在 [cross-site scripting (XSS)](https://zh.wikipedia.org/wiki/跨網站指令碼) 風險之下。所以在 React 裡你還是可以直接注入 HTML，但是你必須使用 `dangerouslySetInnerHTML`，然後傳入一個有 `__html` 為 key 的 object，藉此來提醒你自己這樣做具有風險。例子如下：
 
 ```js
 function createMarkup() {
@@ -55,30 +48,23 @@ function MyComponent() {
 
 ### htmlFor {#htmlfor}
 
-Since `for` is a reserved word in JavaScript, React elements use `htmlFor` instead.
-React element 使用 `htmlFor` 來取代 `for`，因為 `for` 在 JavaScript 是保留字詞。
+React element 使用 `htmlFor` 來替代 `for`，因為 `for` 在 JavaScript 是保留字詞。
 
 ### onChange {#onchange}
 
-The `onChange` event behaves as you would expect it to: whenever a form field is changed, this event is fired. We intentionally do not use the existing browser behavior because `onChange` is a misnomer for its behavior and React relies on this event to handle user input in real time.
 `onChange` event 會表現的跟你預期一樣：當一個表格欄位改變，這個 event 會跟著發生。原先的 `onChange` 是個用詞不夠精確的行為，且 React 依靠這個 event 來處理使用者的即時輸入，所以我們表現出不同於瀏覽器的預設行為。
 
 ### selected {#selected}
 
-The `selected` attribute is supported by `<option>` components. You can use it to set whether the component is selected. This is useful for building controlled components.
-`selected` 這個 attribute 可以被使用在 `<option>` 裡面，用來標示 component 是否已被選取。這對建立 controlled components 很有幫助。
+`selected` 這個 attribute 可以使用在 `<option>` 裡面，用來設置 component 是否已被選取。這對建立 controlled component 很有幫助。
 
 ### style {#style}
 
->Note
->
->Some examples in the documentation use `style` for convenience, but **using the `style` attribute as the primary means of styling elements is generally not recommended.** In most cases, [`className`](#classname) should be used to reference classes defined in an external CSS stylesheet. `style` is most often used in React applications to add dynamically-computed styles at render time. See also [FAQ: Styling and CSS](/docs/faq-styling.html).
 >筆記
 >
->為了方便在文件裡某些範例會使用 `style`，但是**基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。**在大部分的情形， 應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
+>為了方便在文件裡某些範例會使用 `style`，但是 **基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。** 在大部分的情形，應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
 
-The `style` attribute accepts a JavaScript object with camelCased properties rather than a CSS string. This is consistent with the DOM `style` JavaScript property, is more efficient, and prevents XSS security holes. For example:
-`style` attribute 接收一個 JavaScript object 裡頭有駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 是一樣的。
+`style` attribute 接收一個 JavaScript object 裡頭有駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 一致。
 
 ```js
 const divStyle = {
@@ -91,13 +77,12 @@ function HelloWorldComponent() {
 }
 ```
 
-Note that styles are not autoprefixed. To support older browsers, you need to supply corresponding style properties:
 注意 style 不會自動加上前綴。為了要支援舊的瀏覽器，你必須自行提供相對應的 style property。
 
 ```js
 const divStyle = {
   WebkitTransition: 'all', // 注意這裡是大寫的「W」
-  msTransition: 'all' // 「ms」是唯一需要使用小寫前綴的瀏覽器引擎
+  msTransition: 'all' // 「ms」是唯一需要使用小寫開頭的瀏覽器引擎前綴
 };
 
 function ComponentWithTransition() {
@@ -105,11 +90,9 @@ function ComponentWithTransition() {
 }
 ```
 
-Style keys are camelCased in order to be consistent with accessing the properties on DOM nodes from JS (e.g. `node.style.backgroundImage`). Vendor prefixes [other than `ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) should begin with a capital letter. This is why `WebkitTransition` has an uppercase "W".
-為了使用 JavaScript 來存取 DOM nodes，Style keys 也以駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴[除了`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
+為了與使用 JavaScript 來存取 DOM node 一致，style key 也以駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴除了 [`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
 
-React will automatically append a "px" suffix to certain numeric inline style properties. If you want to use units other than "px", specify the value as a string with the desired unit. For example:
-React 會為 style properties 為數字型態的自動加上「px」。如果你想要使用其他單位，以 string 的形式加上單位。舉例來說：
+React 會為某些數字型態的 style property 自動加上「px」。如果你想要使用其他單位，以 string 的形式加上單位。舉例來說：
 
 ```js
 // 輸出 style: '10px'
@@ -123,34 +106,27 @@ React 會為 style properties 為數字型態的自動加上「px」。如果你
 </div>
 ```
 
-Not all style properties are converted to pixel strings though. Certain ones remain unitless (eg `zoom`, `order`, `flex`). A complete list of unitless properties can be seen [here](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59).
 注意所有 style property 都會轉換成 pixel string。只有某些會保持沒有單位，如 `zoom`、`order`、`flex`。沒有單位的 property 完整清單可以在[這裡](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59)查看。
 
 ### suppressContentEditableWarning {#suppresscontenteditablewarning}
 
-Normally, there is a warning when an element with children is also marked as `contentEditable`, because it won't work. This attribute suppresses that warning. Don't use this unless you are building a library like [Draft.js](https://facebook.github.io/draft-js/) that manages `contentEditable` manually.
-通常，當一個 element 的 children 被標示 `contentEditable` 時會有警示訊息，因為這不會有作用。這個 attribute 會抑制警示訊息。除非你在建立一個 library 像是 [Draft.js](https://facebook.github.io/draft-js/)，不要使用它。
+通常當一個 element 的 children 設置 `contentEditable` 時會有警示訊息，因為這不會有作用。這個 attribute 會抑制警示訊息。除非你在建立一個 library 像是 [Draft.js](https://facebook.github.io/draft-js/)，不要使用它。
 
 ### suppressHydrationWarning {#suppresshydrationwarning}
 
-If you use server-side React rendering, normally there is a warning when the server and the client render different content. However, in some rare cases, it is very hard or impossible to guarantee an exact match. For example, timestamps are expected to differ on the server and on the client.
-如果你在使用 server-side React rendering 時 server 和 client render 不同時，通常會有一個警示訊息。然而，在一些很少見的案例，很難去保證 server 和 client side 會完全符合。舉例來說，像是 timestamps 就無法保持相同。
+如果你在使用 server-side React rendering 時 server 和 client render 不同時，通常會有一個警示訊息。然而，在一些很少見的案例，很難去保證 server 和 client side 會完全符合。舉例來說，像是 timestamp 就無法保持相同。
 
-If you set `suppressHydrationWarning` to `true`, React will not warn you about mismatches in the attributes and the content of that element. It only works one level deep, and is intended to be used as an escape hatch. Don't overuse it. You can read more about hydration in the [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate).
-如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 和 element 內容不一樣時，React 就不會有警示訊息。這只有一層深度的作用，且必須要有計畫性地使用。請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
+如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 以及 element 內容不一樣時，React 就不會有警示訊息。這只有作用在一層深度，且要有計畫性地使用。請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
 
 ### value {#value}
 
-The `value` attribute is supported by `<input>` and `<textarea>` components. You can use it to set the value of the component. This is useful for building controlled components. `defaultValue` is the uncontrolled equivalent, which sets the value of the component when it is first mounted.
-`value` attribute 可以被使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是被使用在 uncontrolled component，當初始 mount 後設置 component 的 value。
+`value` attribute 可以使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是使用在 uncontrolled component，當初始 mount 後設置 component 的 value。
 
-## All Supported HTML Attributes {#all-supported-html-attributes}
+## 所有 HTML Attributes 皆可使用 {#all-supported-html-attributes}
 
-As of React 16, any standard [or custom](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes are fully supported.
-在 React 16 中，任何標準[或是自訂](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes 都可以被使用。
+在 React 16 中，任何標準或是[自訂](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes 都可以使用。
 
-React has always provided a JavaScript-centric API to the DOM. Since React components often take both custom and DOM-related props, React uses the `camelCase` convention just like the DOM APIs:
-React 對於 DOM 始終提供以 JavaScript 為中心的 API。React 使用像 DOM API 一樣的 `camelCase` 轉換，因為 React components 通常會有自訂prop，也會有跟 DOM 相關的 prop，
+React 對於 DOM 始終提供以 JavaScript 為中心的 API。因為 React component 通常會有自訂 prop，也會有跟 DOM 相關的 prop，React 使用像 DOM API 一樣的 `camelCase` 轉換。
 
 ```js
 <div tabIndex="-1" />      // 就像 node.tabIndex DOM API
@@ -158,10 +134,8 @@ React 對於 DOM 始終提供以 JavaScript 為中心的 API。React 使用像 D
 <input readOnly={true} />  // 就像 node.readOnly DOM API
 ```
 
-These props work similarly to the corresponding HTML attributes, with the exception of the special cases documented above.
 除了上述文件提到的，這些 prop 跟相對應的 HTML attribute 運作方式一樣。
 
-Some of the DOM attributes supported by React include:
 React 中可以使用這些 DOM attributes：
 
 ```
@@ -180,8 +154,7 @@ sizes span spellCheck src srcDoc srcLang srcSet start step style summary
 tabIndex target title type useMap value width wmode wrap
 ```
 
-Similarly, all SVG attributes are fully supported:
-同樣地，所有 SVG attribute 也可以被使用：
+同樣地，所有 SVG attribute 都可以使用：
 
 ```
 accentHeight accumulate additive alignmentBaseline allowReorder alphabetic
@@ -220,5 +193,4 @@ xlinkHref xlinkRole xlinkShow xlinkTitle xlinkType xmlns xmlnsXlink xmlBase
 xmlLang xmlSpace y y1 y2 yChannelSelector z zoomAndPan
 ```
 
-You may also use custom attributes as long as they're fully lowercase.
 你也可以使用全部小寫表示自訂 attribute。

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -14,9 +14,9 @@ redirect_from:
   - "tips/dangerously-set-inner-html.html"
 ---
 
-為了能兼具跨瀏覽器相容與效能，React 實踐了一套獨立於瀏覽器的 DOM 系統，並把握機會優化了瀏覽器 DOM 美中不足之處。
+為了能兼具效能與跨瀏覽器的兼容性，React 實作了一套獨立於瀏覽器的 DOM 系統，我們藉由這個機會解決瀏覽器 DOM 的美中不足之處。
 
-在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以小駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 保持原樣即可。
+在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以 camelCase 命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 保持原樣即可。
 
 ## Attributes 相異之處 {#differences-in-attributes}
 
@@ -24,7 +24,7 @@ redirect_from:
 
 ### checked {#checked}
 
-當 `<input>` 的 type 是 `checkbox` 或是 `radio` 時，可以使用 `checked` 這個 attribute 來設置 component 是否被選取。這對建立 controlled component 很有幫助。`defaultChecked` 則是使用在 uncontrolled component，當初始 mount 後設置 component 是否被選取。
+當 `<input>` 的 type 是 `checkbox` 或是 `radio` 時，可以使用 `checked` 這個 attribute 來設置 component 是否被選取。這對建立 controlled component 很有幫助。`defaultChecked` 則是使用在 uncontrolled component，在初始 mount 後設置 component 是否被選取。
 
 ### className {#classname}
 
@@ -34,7 +34,7 @@ redirect_from:
 
 ### dangerouslySetInnerHTML {#dangerouslysetinnerhtml}
 
-`dangerouslySetInnerHTML` 是 React 用來替代 DOM 的 `innerHTML`。普遍來說，從程式碼中注入 HTML 是個冒險的行為，你會很輕易地讓使用者暴露在 [cross-site scripting (XSS)](https://zh.wikipedia.org/wiki/跨網站指令碼) 風險之下。所以在 React 裡你還是可以直接注入 HTML，但是你必須使用 `dangerouslySetInnerHTML`，然後傳入一個有 `__html` 為 key 的 object，藉此來提醒你自己這樣做具有風險。例子如下：
+`dangerouslySetInnerHTML` 是 React 用來替代 DOM 的 `innerHTML`。普遍來說，從程式碼中注入 HTML 是個冒險的行為，你會很輕易地讓使用者暴露在 [cross-site scripting (XSS)](https://zh.wikipedia.org/wiki/跨網站指令碼) 攻擊風險之下。所以在 React 裡你還是可以直接注入 HTML，但是你必須使用 `dangerouslySetInnerHTML`，然後傳入一個有 `__html` 為 key 的 object，藉此來提醒你自己這樣做具有風險。例如：
 
 ```js
 function createMarkup() {
@@ -62,9 +62,9 @@ React element 使用 `htmlFor` 來替代 `for`，因為 `for` 在 JavaScript 是
 
 >注意
 >
->為了方便在文件裡某些範例會使用 `style`，但是**基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。**在大部分的情形，應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
+>為了方便在文件裡某些範例會使用 `style`，但是**基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。**在大部分的情形，應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的增加方式。請參考 [FAQ: Styling and CSS](/docs/faq-styling.html)。
 
-`style` attribute 接收一個 JavaScript object 裡頭有小駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 一致。
+`style` attribute 接收一個 JavaScript object 內含以 camelCase 命名的 property，而不是 CSS string。這與 DOM `style` JavaScript property 一致，但效率更高，並且可以防止 XSS 安全漏洞。例如：
 
 ```js
 const divStyle = {
@@ -90,7 +90,7 @@ function ComponentWithTransition() {
 }
 ```
 
-為了與使用 JavaScript 來存取 DOM node 一致，style key 也以小駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴除了 [`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
+為了與使用 JavaScript 來存取 DOM node 一致，style key 也以 camelCase 命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴除了 [`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
 
 React 會為某些數字型態的 style property 自動加上「px」。如果你想要使用其他單位，以 string 的形式加上單位。舉例來說：
 
@@ -106,27 +106,27 @@ React 會為某些數字型態的 style property 自動加上「px」。如果�
 </div>
 ```
 
-注意所有 style property 都會轉換成 pixel string。只有某些會保持沒有單位，如 `zoom`、`order`、`flex`。沒有單位的 property 完整清單可以在[這裡](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59)查看。
+注意所有 style property 都會轉換成 pixel string。只有某些會保持沒有單位，如 `zoom`、`order`、`flex`。沒有單位的 property 完整列表可以在[這裡](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59)查看。
 
 ### suppressContentEditableWarning {#suppresscontenteditablewarning}
 
-通常當一個 element 的 children 設置 `contentEditable` 時，因為不會有作用，所以會有警示訊息。這個 attribute 會抑制警示訊息。不要使用它，除非你在建立一個像是 [Draft.js](https://facebook.github.io/draft-js/) 的 library。
+通常來說，當一個 element 的 children 設置 `contentEditable` 時，因為不會有作用，所以會有警示訊息。這個 attribute 會抑制警示訊息。除非你在建立一個像是 [Draft.js](https://facebook.github.io/draft-js/) 的 library，否則不要使用它。
 
 ### suppressHydrationWarning {#suppresshydrationwarning}
 
-如果你在使用 server-side React rendering 時 server 和 client render 不同時，通常會有一個警示訊息。然而，在一些很少見的案例，很難去保證 server 和 client side 會完全符合。舉例來說，像是 timestamp 就無法保持相同。
+如果你使用 server-side React render 時，通常 server 和 client render 不同時，會有一個警示訊息。然而，在一些少數的案例，很難去保證 server 和 client side 會完全符合。例如，像是 timestamp 就無法在 server 和 client 保持相同。
 
-如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 以及 element 內容不一樣時，React 就不會有警示訊息。這只有作用在一層深度，且需要有計畫性地使用，請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
+如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 以及 element 內容不一樣時，React 就不會有警示訊息。這只作用在一層深度，且需要有計畫性地使用，請勿濫用。你可以在 [`ReactDOM.hydrate()` 文件](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
 
 ### value {#value}
 
-`value` attribute 可以使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是使用在 uncontrolled component，當初始 mount 後設置 component 的 value。
+`value` attribute 可以使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是使用在 uncontrolled component，在初始 mount 後設置 component 的 value。
 
 ## 可以使用的 HTML Attribute {#all-supported-html-attributes}
 
-在 React 16 中，任何標準或是[自訂](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes 都可以使用。
+在 React 16 中，任何標準[或是自訂的](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attribute 都可以使用。
 
-React 為 DOM 提供了一套以 JavaScript 為中心的 API。因為 React component 通常會有自訂或跟 DOM 相關的 prop，React 使用像 DOM API 一樣的 `小駝峰式命名`。
+React 為 DOM 提供了一套以 JavaScript 為中心的 API。因為 React component 通常會有自訂或跟 DOM 相關的 prop，React 使用像 DOM API 一樣的 `camelCase`。
 
 ```js
 <div tabIndex="-1" />      // 就像 node.tabIndex DOM API
@@ -136,7 +136,7 @@ React 為 DOM 提供了一套以 JavaScript 為中心的 API。因為 React comp
 
 除了上述文件提到的，這些 prop 跟對應的 HTML attribute 運作方式一樣。
 
-React 中可以使用這些 DOM attributes：
+React 中可以使用這些 DOM attribute：
 
 ```
 accept acceptCharset accessKey action allowFullScreen alt async autoComplete
@@ -193,4 +193,4 @@ xlinkHref xlinkRole xlinkShow xlinkTitle xlinkType xmlns xmlnsXlink xmlBase
 xmlLang xmlSpace y y1 y2 yChannelSelector z zoomAndPan
 ```
 
-你也可以使用全部小寫表示自訂 attribute。
+你也可以使用自訂的 attribute，只要它們是完全小寫的。

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -15,26 +15,33 @@ redirect_from:
 ---
 
 React implements a browser-independent DOM system for performance and cross-browser compatibility. We took the opportunity to clean up a few rough edges in browser DOM implementations.
+React 實踐了一個具有效能且跨瀏覽器兼容的 DOM system。並在實踐的過程中，優化 DOM 美中不足之處。
 
 In React, all DOM properties and attributes (including event handlers) should be camelCased. For example, the HTML attribute `tabindex` corresponds to the attribute `tabIndex` in React. The exception is `aria-*` and `data-*` attributes, which should be lowercased. For example, you can keep `aria-label` as `aria-label`.
+在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 應該保持 `aria-label` 原樣。
 
-## Differences In Attributes {#differences-in-attributes}
+## Attributes 相異之處 {#differences-in-attributes}
 
 There are a number of attributes that work differently between React and HTML:
+有些 attribute 在 React 和 HTML 之間運作的方式略為不同：
 
 ### checked {#checked}
 
 The `checked` attribute is supported by `<input>` components of type `checkbox` or `radio`. You can use it to set whether the component is checked. This is useful for building controlled components. `defaultChecked` is the uncontrolled equivalent, which sets whether the component is checked when it is first mounted.
+當 `<input>` 的 type 是 `checkbox` 或是 `radio` 時，可以使用 `checked` 這個 attribute 來設置 component 是否被選取。這在建立 controlled component 時很有幫助。`defaultChecked` 則是被使用在 uncontrolled component，當初始 mount 後設置 component 是否被選取。
 
 ### className {#classname}
 
 To specify a CSS class, use the `className` attribute. This applies to all regular DOM and SVG elements like `<div>`, `<a>`, and others.
+要指定一個 CSS class 時，使用 `className` attribute。這在所有常規的 DOM 和 SVG element 像是 `<div>`、`<a>` 還有其他的都能適用。
 
 If you use React with Web Components (which is uncommon), use the `class` attribute instead.
+如果你在 React 裡使用 Web Components（這不是常見的狀況），則使用 `class`。
 
 ### dangerouslySetInnerHTML {#dangerouslysetinnerhtml}
 
 `dangerouslySetInnerHTML` is React's replacement for using `innerHTML` in the browser DOM. In general, setting HTML from code is risky because it's easy to inadvertently expose your users to a [cross-site scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) attack. So, you can set HTML directly from React, but you have to type out `dangerouslySetInnerHTML` and pass an object with a `__html` key, to remind yourself that it's dangerous. For example:
+`dangerouslySetInnerHTML` 是 React 用來替代 DOM 的 `innerHTML`。普遍來說，從程式碼中注入 HTML 是個冒險的行為，很輕易地你就會讓使用者暴露在 [cross-site scripting (XSS)](https://zh.wikipedia.org/wiki/跨網站指令碼) 風險之下。所以，在 React 裡你還是可以直接注入 HTML，但是你必須使用 `dangerouslySetInnerHTML`，然後傳入一個有 `__html` 為 key 的物件，藉此來提醒你自己這樣做具有風險。例子如下：
 
 ```js
 function createMarkup() {
@@ -49,22 +56,29 @@ function MyComponent() {
 ### htmlFor {#htmlfor}
 
 Since `for` is a reserved word in JavaScript, React elements use `htmlFor` instead.
+React element 使用 `htmlFor` 來取代 `for`，因為 `for` 在 JavaScript 是保留字詞。
 
 ### onChange {#onchange}
 
 The `onChange` event behaves as you would expect it to: whenever a form field is changed, this event is fired. We intentionally do not use the existing browser behavior because `onChange` is a misnomer for its behavior and React relies on this event to handle user input in real time.
+`onChange` event 會表現的跟你預期一樣：當一個表格欄位改變，這個 event 會跟著發生。原先的 `onChange` 是個用詞不夠精確的行為，且 React 依靠這個 event 來處理使用者的即時輸入，所以我們表現出不同於瀏覽器的預設行為。
 
 ### selected {#selected}
 
 The `selected` attribute is supported by `<option>` components. You can use it to set whether the component is selected. This is useful for building controlled components.
+`selected` 這個 attribute 可以被使用在 `<option>` 裡面，用來標示 component 是否已被選取。這對建立 controlled components 很有幫助。
 
 ### style {#style}
 
 >Note
 >
 >Some examples in the documentation use `style` for convenience, but **using the `style` attribute as the primary means of styling elements is generally not recommended.** In most cases, [`className`](#classname) should be used to reference classes defined in an external CSS stylesheet. `style` is most often used in React applications to add dynamically-computed styles at render time. See also [FAQ: Styling and CSS](/docs/faq-styling.html).
+>筆記
+>
+>為了方便在文件裡某些範例會使用 `style`，但是**基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。**在大部分的情形， 應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
 
 The `style` attribute accepts a JavaScript object with camelCased properties rather than a CSS string. This is consistent with the DOM `style` JavaScript property, is more efficient, and prevents XSS security holes. For example:
+`style` attribute 接收一個 JavaScript object 裡頭有駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 是一樣的。
 
 ```js
 const divStyle = {
@@ -78,11 +92,12 @@ function HelloWorldComponent() {
 ```
 
 Note that styles are not autoprefixed. To support older browsers, you need to supply corresponding style properties:
+注意 style 不會自動加上前綴。為了要支援舊的瀏覽器，你必須自行提供相對應的 style property。
 
 ```js
 const divStyle = {
-  WebkitTransition: 'all', // note the capital 'W' here
-  msTransition: 'all' // 'ms' is the only lowercase vendor prefix
+  WebkitTransition: 'all', // 注意這裡是大寫的「W」
+  msTransition: 'all' // 「ms」是唯一需要使用小寫前綴的瀏覽器引擎
 };
 
 function ComponentWithTransition() {
@@ -91,52 +106,63 @@ function ComponentWithTransition() {
 ```
 
 Style keys are camelCased in order to be consistent with accessing the properties on DOM nodes from JS (e.g. `node.style.backgroundImage`). Vendor prefixes [other than `ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) should begin with a capital letter. This is why `WebkitTransition` has an uppercase "W".
+為了使用 JavaScript 來存取 DOM nodes，Style keys 也以駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴[除了`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
 
 React will automatically append a "px" suffix to certain numeric inline style properties. If you want to use units other than "px", specify the value as a string with the desired unit. For example:
+React 會為 style properties 為數字型態的自動加上「px」。如果你想要使用其他單位，以 string 的形式加上單位。舉例來說：
 
 ```js
-// Result style: '10px'
+// 輸出 style: '10px'
 <div style={{ height: 10 }}>
   Hello World!
 </div>
 
-// Result style: '10%'
+// 輸出 style: '10%'
 <div style={{ height: '10%' }}>
   Hello World!
 </div>
 ```
 
 Not all style properties are converted to pixel strings though. Certain ones remain unitless (eg `zoom`, `order`, `flex`). A complete list of unitless properties can be seen [here](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59).
+注意所有 style property 都會轉換成 pixel string。只有某些會保持沒有單位，如 `zoom`、`order`、`flex`。沒有單位的 property 完整清單可以在[這裡](https://github.com/facebook/react/blob/4131af3e4bf52f3a003537ec95a1655147c81270/src/renderers/dom/shared/CSSProperty.js#L15-L59)查看。
 
 ### suppressContentEditableWarning {#suppresscontenteditablewarning}
 
 Normally, there is a warning when an element with children is also marked as `contentEditable`, because it won't work. This attribute suppresses that warning. Don't use this unless you are building a library like [Draft.js](https://facebook.github.io/draft-js/) that manages `contentEditable` manually.
+通常，當一個 element 的 children 被標示 `contentEditable` 時會有警示訊息，因為這不會有作用。這個 attribute 會抑制警示訊息。除非你在建立一個 library 像是 [Draft.js](https://facebook.github.io/draft-js/)，不要使用它。
 
 ### suppressHydrationWarning {#suppresshydrationwarning}
 
 If you use server-side React rendering, normally there is a warning when the server and the client render different content. However, in some rare cases, it is very hard or impossible to guarantee an exact match. For example, timestamps are expected to differ on the server and on the client.
+如果你在使用 server-side React rendering 時 server 和 client render 不同時，通常會有一個警示訊息。然而，在一些很少見的案例，很難去保證 server 和 client side 會完全符合。舉例來說，像是 timestamps 就無法保持相同。
 
 If you set `suppressHydrationWarning` to `true`, React will not warn you about mismatches in the attributes and the content of that element. It only works one level deep, and is intended to be used as an escape hatch. Don't overuse it. You can read more about hydration in the [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate).
+如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 和 element 內容不一樣時，React 就不會有警示訊息。這只有一層深度的作用，且必須要有計畫性地使用。請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
 
 ### value {#value}
 
 The `value` attribute is supported by `<input>` and `<textarea>` components. You can use it to set the value of the component. This is useful for building controlled components. `defaultValue` is the uncontrolled equivalent, which sets the value of the component when it is first mounted.
+`value` attribute 可以被使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是被使用在 uncontrolled component，當初始 mount 後設置 component 的 value。
 
 ## All Supported HTML Attributes {#all-supported-html-attributes}
 
 As of React 16, any standard [or custom](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes are fully supported.
+在 React 16 中，任何標準[或是自訂](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes 都可以被使用。
 
 React has always provided a JavaScript-centric API to the DOM. Since React components often take both custom and DOM-related props, React uses the `camelCase` convention just like the DOM APIs:
+React 對於 DOM 始終提供以 JavaScript 為中心的 API。React 使用像 DOM API 一樣的 `camelCase` 轉換，因為 React components 通常會有自訂prop，也會有跟 DOM 相關的 prop，
 
 ```js
-<div tabIndex="-1" />      // Just like node.tabIndex DOM API
-<div className="Button" /> // Just like node.className DOM API
-<input readOnly={true} />  // Just like node.readOnly DOM API
+<div tabIndex="-1" />      // 就像 node.tabIndex DOM API
+<div className="Button" /> // 就像 node.className DOM API
+<input readOnly={true} />  // 就像 node.readOnly DOM API
 ```
 
 These props work similarly to the corresponding HTML attributes, with the exception of the special cases documented above.
+除了上述文件提到的，這些 prop 跟相對應的 HTML attribute 運作方式一樣。
 
 Some of the DOM attributes supported by React include:
+React 中可以使用這些 DOM attributes：
 
 ```
 accept acceptCharset accessKey action allowFullScreen alt async autoComplete
@@ -155,6 +181,7 @@ tabIndex target title type useMap value width wmode wrap
 ```
 
 Similarly, all SVG attributes are fully supported:
+同樣地，所有 SVG attribute 也可以被使用：
 
 ```
 accentHeight accumulate additive alignmentBaseline allowReorder alphabetic
@@ -194,3 +221,4 @@ xmlLang xmlSpace y y1 y2 yChannelSelector z zoomAndPan
 ```
 
 You may also use custom attributes as long as they're fully lowercase.
+你也可以使用全部小寫表示自訂 attribute。

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -14,9 +14,9 @@ redirect_from:
   - "tips/dangerously-set-inner-html.html"
 ---
 
-React 實踐了一個具有效能且跨瀏覽器兼容的 DOM system。並在實踐的過程中，優化 DOM 美中不足之處。
+為了能兼具跨瀏覽器相容與效能，React 實踐了一套獨立於瀏覽器的 DOM 系統，並把握機會優化了瀏覽器 DOM 美中不足之處。
 
-在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 保持原樣即可。
+在 React 裡，所有 DOM property 和 attribute（包括 event handler）都應該以小駝峰式命名。舉例來說，HTML 的 attribute `tabindex` 在 React 中對應到 `tabIndex`。`aria-*` 和 `data-*` attribute 則是例外，需要保持全部小寫。舉例來說，`aria-label` 保持原樣即可。
 
 ## Attributes 相異之處 {#differences-in-attributes}
 
@@ -28,9 +28,9 @@ React 實踐了一個具有效能且跨瀏覽器兼容的 DOM system。並在實
 
 ### className {#classname}
 
-要指定一個 CSS class 時，使用 `className` attribute。這在所有常規的 DOM 和 SVG element 像是 `<div>`、`<a>` 還有其他的都能適用。
+要指定一個 CSS class 時，使用 `className` attribute。這在所有標準的 DOM 和 SVG element 像是 `<div>`、`<a>` 或其他的都能適用。
 
-如果你在 React 裡使用 Web Component（這不是常見的狀況），則使用 `class`。
+如果你在 React 裡使用 Web Components（這不是常見的狀況），則使用 `class`。
 
 ### dangerouslySetInnerHTML {#dangerouslysetinnerhtml}
 
@@ -48,11 +48,11 @@ function MyComponent() {
 
 ### htmlFor {#htmlfor}
 
-React element 使用 `htmlFor` 來替代 `for`，因為 `for` 在 JavaScript 是保留字詞。
+React element 使用 `htmlFor` 來替代 `for`，因為 `for` 在 JavaScript 是保留字。
 
 ### onChange {#onchange}
 
-`onChange` event 會表現的跟你預期一樣：當一個表格欄位改變，這個 event 會跟著發生。原先的 `onChange` 是個用詞不夠精確的行為，且 React 依靠這個 event 來處理使用者的即時輸入，所以我們表現出不同於瀏覽器的預設行為。
+`onChange` event 會表現的跟你預期一樣：每當表格欄位值改變，這個 event 跟著發生。原先的 `onChange` 是個用詞不夠精確的行為，且 React 依靠這個 event 來處理使用者的即時輸入，所以我們表現出不同於瀏覽器的預設行為。
 
 ### selected {#selected}
 
@@ -60,11 +60,11 @@ React element 使用 `htmlFor` 來替代 `for`，因為 `for` 在 JavaScript 是
 
 ### style {#style}
 
->筆記
+>注意
 >
->為了方便在文件裡某些範例會使用 `style`，但是 **基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。** 在大部分的情形，應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
+>為了方便在文件裡某些範例會使用 `style`，但是**基本上不推薦使用 `style` attribute 作為初步修飾 elements 的手段。**在大部分的情形，應該使用[`className`](#classname) 來對應定義在外部 CSS stylesheet 的 class。`style` 通常在 React 應用中會被用做動態 style 的添加方式。也看看 [FAQ: Styling and CSS](/docs/faq-styling.html)。
 
-`style` attribute 接收一個 JavaScript object 裡頭有駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 一致。
+`style` attribute 接收一個 JavaScript object 裡頭有小駝峰式命名的 property，而不是 CSS string。這跟 DOM `style` JavaScript property 一致。
 
 ```js
 const divStyle = {
@@ -90,7 +90,7 @@ function ComponentWithTransition() {
 }
 ```
 
-為了與使用 JavaScript 來存取 DOM node 一致，style key 也以駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴除了 [`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
+為了與使用 JavaScript 來存取 DOM node 一致，style key 也以小駝峰式命名 (e.g. `node.style.backgroundImage`)。瀏覽器引擎前綴除了 [`ms`](https://www.andismith.com/blogs/2012/02/modernizr-prefixed/) 都應該以一個大寫字母開頭。這就是 `WebkitTransition` 為什麼有一個大寫「W」的原因。
 
 React 會為某些數字型態的 style property 自動加上「px」。如果你想要使用其他單位，以 string 的形式加上單位。舉例來說：
 
@@ -110,23 +110,23 @@ React 會為某些數字型態的 style property 自動加上「px」。如果�
 
 ### suppressContentEditableWarning {#suppresscontenteditablewarning}
 
-通常當一個 element 的 children 設置 `contentEditable` 時會有警示訊息，因為這不會有作用。這個 attribute 會抑制警示訊息。除非你在建立一個 library 像是 [Draft.js](https://facebook.github.io/draft-js/)，不要使用它。
+通常當一個 element 的 children 設置 `contentEditable` 時，因為不會有作用，所以會有警示訊息。這個 attribute 會抑制警示訊息。不要使用它，除非你在建立一個像是 [Draft.js](https://facebook.github.io/draft-js/) 的 library。
 
 ### suppressHydrationWarning {#suppresshydrationwarning}
 
 如果你在使用 server-side React rendering 時 server 和 client render 不同時，通常會有一個警示訊息。然而，在一些很少見的案例，很難去保證 server 和 client side 會完全符合。舉例來說，像是 timestamp 就無法保持相同。
 
-如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 以及 element 內容不一樣時，React 就不會有警示訊息。這只有作用在一層深度，且要有計畫性地使用。請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
+如果你設置了 `suppressHydrationWarning` 為 `true`，attribute 以及 element 內容不一樣時，React 就不會有警示訊息。這只有作用在一層深度，且需要有計畫性地使用，請勿濫用。你可以在 [`ReactDOM.hydrate()` documentation](/docs/react-dom.html#hydrate) 讀到更多關於 hydration。
 
 ### value {#value}
 
 `value` attribute 可以使用在 `<input>` 和 `<textarea>` component。你可以使用它來設置 component value。這對建立 controlled component 很有幫助。`defaultValue` 則是使用在 uncontrolled component，當初始 mount 後設置 component 的 value。
 
-## 所有 HTML Attributes 皆可使用 {#all-supported-html-attributes}
+## 可以使用的 HTML Attribute {#all-supported-html-attributes}
 
 在 React 16 中，任何標準或是[自訂](/blog/2017/09/08/dom-attributes-in-react-16.html) DOM attributes 都可以使用。
 
-React 對於 DOM 始終提供以 JavaScript 為中心的 API。因為 React component 通常會有自訂 prop，也會有跟 DOM 相關的 prop，React 使用像 DOM API 一樣的 `camelCase` 轉換。
+React 為 DOM 提供了一套以 JavaScript 為中心的 API。因為 React component 通常會有自訂或跟 DOM 相關的 prop，React 使用像 DOM API 一樣的 `小駝峰式命名`。
 
 ```js
 <div tabIndex="-1" />      // 就像 node.tabIndex DOM API
@@ -134,7 +134,7 @@ React 對於 DOM 始終提供以 JavaScript 為中心的 API。因為 React comp
 <input readOnly={true} />  // 就像 node.readOnly DOM API
 ```
 
-除了上述文件提到的，這些 prop 跟相對應的 HTML attribute 運作方式一樣。
+除了上述文件提到的，這些 prop 跟對應的 HTML attribute 運作方式一樣。
 
 React 中可以使用這些 DOM attributes：
 


### PR DESCRIPTION
Besides words mentioned in [Glossary](https://github.com/reactjs/zh-hant.reactjs.org/wiki/Glossary), I remain these untranslated.
- `server`/`client` (side)
- `style`
- `timestamp`
- `key`
- `property`
- `pixel`
- `camelCase`
- `controlled component`

Welcome for further discussion.