### PR TITLE
fix: remove * symbol avoid display undefined text

### DIFF
--- a/content/docs/hello-world.md
+++ b/content/docs/hello-world.md
@@ -17,7 +17,7 @@ ReactDOM.render(
 
 在頁面上顯示「Hello, world!」。
 
-[](codepen://hello-world)
+[在 CodePen 上試試看吧！](codepen://hello-world)
 
 點擊上方連結開啟線上編輯器。請隨意的變更程式碼並觀察它們的輸出變化。大部分的文件頁面都有像這樣可以編輯的範例。
 

--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -68,7 +68,7 @@ ReactDOM.render(
 );
 ```
 
-[](codepen://introducing-jsx)
+[在 CodePen 上試試看吧！](codepen://introducing-jsx)
 
 為了方便閱讀，我們將 JSX 拆成很多行表達。雖然這並不需要，我們建議將多行 JSX 包在括號中來避免遇到[自動分號補足](http://stackoverflow.com/q/2846283)的麻煩。
 

--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -38,7 +38,7 @@ const element = <h1>Hello, world</h1>;
 
 `embed:rendering-elements/render-an-element.js`
 
-[**在 CodePen 上試試看吧！**](codepen://rendering-elements/render-an-element)
+[在 CodePen 上試試看吧！](codepen://rendering-elements/render-an-element)
 
 在網頁上你會看見顯示「Hello, world」。
 
@@ -52,7 +52,7 @@ React element 是 [immutable](https://en.wikipedia.org/wiki/Immutable_object) �
 
 `embed:rendering-elements/update-rendered-element.js`
 
-[**在 CodePen 上試試看吧！**](codepen://rendering-elements/update-rendered-element)
+[在 CodePen 上試試看吧！](codepen://rendering-elements/update-rendered-element)
 
 它從 [`setInterval()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval) callback 每秒呼叫 `ReactDOM.render()`。
 


### PR DESCRIPTION
<img width="931" alt="螢幕快照 2019-11-05 上午11 35 22" src="https://user-images.githubusercontent.com/10325111/68176632-992a4a00-ffc0-11e9-81ba-99ac3e8e338c.png">

I found some Codepen link text is `undefined` and removed the bold symbol. It can display correctly.