### PR TITLE
自訂 is more appropriate

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -33,7 +33,7 @@ function Example() {
 }
 ```
 
-這個範例基於[上一頁的計數器範例](/docs/hooks-state.html)，但是我們增加了一個新的功能：我們把網頁標題設定為包含點擊次數的自定義訊息。
+這個範例基於[上一頁的計數器範例](/docs/hooks-state.html)，但是我們增加了一個新的功能：我們把網頁標題設定為包含點擊次數的自訂訊息。
 
 資料 fetch、設定 subscription、或手動改變 React component 中的 DOM 都是 side effect 的範例。無論你是否習慣將這些操作稱為「side effect」（或簡稱「effect」），你之前可能已經在 component 中執行了這些操作。
 


### PR DESCRIPTION
自訂 is more appropriate. It means custom or customized.   自定義 means self-defining or self-defined and it is too heavy.  It is not "self defining" but is self-defined and It just means a custom message. In fact, it could have been 我們把網頁標題設定為包含點擊次數的訊息。

The word "custom" is not even needed, because we are saying "we set it to a message that includes the number of clicks", and the meaning of "custom" is very apparent.  We could use the word 自訂 if we want to stick to the original English sentence as close as possible.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
