### PR TITLE
你有*很多*可以去做 is "You have a lot can go do"

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -482,7 +482,7 @@ useEffect(() => {
 
 ## 下一步 {#next-steps}
 
-恭喜！這一頁很長，但是希望讀到最後，你絕大多數的問題都有了答案。你已經學過 State Hook 和 Effect Hook，把兩者結合起來，你有*很多*可以去做。它們涵蓋了 class 的絕大多數的使用案例 — 如果沒有涵蓋到，[額外的 Hook](/docs/hooks-reference.html) 或許會幫到你。
+恭喜！這一頁很長，但是希望讀到最後，你絕大多數的問題都有了答案。你已經學過 State Hook 和 Effect Hook，把兩者結合起來，你已經能做到*很多*東西。它們涵蓋了 class 的絕大多數的使用案例 — 如果沒有涵蓋到，[額外的 Hook](/docs/hooks-reference.html) 或許會幫到你。
 
 我們也開始看到 Hook 如何解決[動機](/docs/hooks-intro.html#motivation)中概述的問題。我們已經看到了 effect 清除如何避免在 `componentDidUpdate` 和 `componentWillUnmount` 中重複，如何使相關程式碼更緊密地結合在一起，並幫助我們避免 bug。我們還看到了我們可以如何根據 effect 的目的來區分 effect，這是我們在 class 中根本無法做到的。
 


### PR DESCRIPTION
你有*很多*可以去做 is "You have a lot can go do" doesn't sound right.

The English version is "there is a lot you can do with both of them combined"

it means:

把兩者結合起來，你已經能做到很多東西。

combining both, you already can do a lot of things.

你有*很多*可以去做 is "You have a lot can go do"  or "You have a lot can do"  They don't sound right.

The English version has "a lot" in italic, so it is done for the translation as well, for 很多.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
