### PR TITLE
Fix typo in useYourImagination() section

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -197,11 +197,11 @@ function ChatRecipientPicker() {
 
 ## `useYourImagination()` {#useyourimagination}
 
-自定義的 Hook 提供了共享邏輯的靈活性，這在以前的 React component 是不可能的。你可以撰寫自定義的 Hook 涵蓋廣泛的場景，想是表格處理、動畫、陳述式訂閱（Declarative Subscription）、計時器還有更多我們沒有考慮過的。更重要的是，你可以打造與 React 的內建一樣易於使用的 Hook。
+自定義的 Hook 提供了共享邏輯的靈活性，這在以前的 React component 是不可能的。你可以撰寫自定義的 Hook 涵蓋廣泛的場景，像是表格處理、動畫、陳述式訂閱（Declarative Subscription）、計時器還有更多我們沒有考慮過的。更重要的是，你可以打造與 React 的內建一樣易於使用的 Hook。
 
 盡量不要過早地加入抽象。現在 function component 可以做更多的事，在你 codebase 中的 function component 程式碼平均可能都會變得更長。這都是正常的 -- 不要覺得你*必須*馬上把它拆分成 Hook。但我們也鼓勵你開始發現自定義的 Hook 可以隱藏簡單 interface 背後的複雜邏輯情況，或者幫忙解開一個混亂的 component。
 
-例如，你可能有一個複雜的 component，它包含許多以 ad-hoc 的方式來管理 local state。`useState` 沒辦法讓更新邏輯集中化，所以你可能更傾向將其寫為 [Redux](https://redux.js.org/) 的 reducer：
+例如，你可能有一個複雜的 component，它包含許多以一個特殊目的（ad-hoc）方式來管理的 local state。`useState` 沒辦法讓更新邏輯集中化，所以你可能更傾向將其寫為 [Redux](https://redux.js.org/) 的 reducer：
 
 ```js
 function todosReducer(state, action) {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixed `想是` -> `像是`
Also ad-hoc may not be understandable for some traditional Chinese readers.
