### PR TITLE
docs(hooks): useContext

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -4,7 +4,7 @@ title: useContext
 
 <Intro>
 
-`useContext` is a React Hook that lets you read and subscribe to [context](/learn/passing-data-deeply-with-context) from your component.
+`useContext` 是一個 React Hook，讓你從元件中讀取和訂閱（subscribe） [context](/learn/passing-data-deeply-with-context)。
 
 ```js
 const value = useContext(SomeContext)
@@ -16,11 +16,11 @@ const value = useContext(SomeContext)
 
 ---
 
-## Reference {/*reference*/}
+## 參考 {/*reference*/}
 
 ### `useContext(SomeContext)` {/*usecontext*/}
 
-Call `useContext` at the top level of your component to read and subscribe to [context.](/learn/passing-data-deeply-with-context)
+在元件的頂層呼叫 `useContext` 以讀取和訂閱 [context](/learn/passing-data-deeply-with-context)。
 
 ```js
 import { useContext } from 'react';
@@ -30,30 +30,29 @@ function MyComponent() {
   // ...
 ```
 
-[See more examples below.](#usage)
+[往下查看更多範例。](#usage)
 
-#### Parameters {/*parameters*/}
+#### 參數 {/*parameters*/}
 
-* `SomeContext`: The context that you've previously created with [`createContext`](/reference/react/createContext). The context itself does not hold the information, it only represents the kind of information you can provide or read from components.
+* `SomeContext`: 你已經預先用 [`createContext`](/reference/react/createContext) 創建的 context。這個 context 本身不儲存資訊，只代表元件可以提供或讀取的資訊種類。
 
-#### Returns {/*returns*/}
+#### 回傳值 {/*returns*/}
 
-`useContext` returns the context value for the calling component. It is determined as the `value` passed to the closest `SomeContext` above the calling component in the tree. If there is no such provider, then the returned value will be the `defaultValue` you have passed to [`createContext`](/reference/react/createContext) for that context. The returned value is always up-to-date. React automatically re-renders components that read some context if it changes.
+`useContext` 會回傳呼叫元件的 context 值。這個值是由元件樹中距離呼叫元件上方最近的 `SomeContext`，所傳入的 `value` 來決定。如果沒有像這樣的 provider，回傳值就會是你在建立這個 context 時，傳入 [`createContext`](/reference/react/createContext) 的 `defaultValue`。回傳值總是最新的。如果 context 發生變化，React 會自動重新渲染（re-render）讀取這些 context 的元件。
 
-#### Caveats {/*caveats*/}
+#### 注意事項 {/*caveats*/}
 
-* `useContext()` call in a component is not affected by providers returned from the *same* component. The corresponding `<Context>` **needs to be *above*** the component doing the `useContext()` call.
-* React **automatically re-renders** all the children that use a particular context starting from the provider that receives a different `value`. The previous and the next values are compared with the [`Object.is`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) comparison. Skipping re-renders with [`memo`](/reference/react/memo) does not prevent the children receiving fresh context values.
-* If your build system produces duplicates modules in the output (which can happen with symlinks), this can break context. Passing something via context only works if `SomeContext` that you use to provide context and `SomeContext` that you use to read it are ***exactly* the same object**, as determined by a `===` comparison.
+* 元件中所呼叫的 `useContext()` 並不會被 *同一個* 元件所回傳的 provider 影響。對應的 `<Context>` **必須位於呼叫 `useContext()` 的元件 *上方***。
+* React 會 **自動重新渲染** 所有使用特定 context 並從 provider 接收不同 `value` 的子元件。渲染之前和之後的值會用 [`Object.is`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) 來作比較。用 [`memo`](/reference/react/memo) 跳過重新渲染，並不能阻止子元件接收 context 的新值。
+* 如果你建置（build）的系統在輸出過程中產生重複的模組（可能會發生在符號連結（symlink）），會破壞 context。只在當用來提供 context 的 `SomeContext`  與用來讀取它的 `SomeContext` 是 ***完全* 相同的物件** 時，透過 context 傳遞資料才會正常運作，這是由 `===` 的比較所決定。
 
 ---
 
-## Usage {/*usage*/}
+## 使用 {/*usage*/}
 
+### 將資料傳入元件樹的深處 {/*passing-data-deeply-into-the-tree*/}
 
-### Passing data deeply into the tree {/*passing-data-deeply-into-the-tree*/}
-
-Call `useContext` at the top level of your component to read and subscribe to [context.](/learn/passing-data-deeply-with-context)
+在元件的頂層呼叫 `useContext` 以讀取和訂閱 [context](/learn/passing-data-deeply-with-context)。
 
 ```js [[2, 4, "theme"], [1, 4, "ThemeContext"]]
 import { useContext } from 'react';
@@ -63,9 +62,9 @@ function Button() {
   // ... 
 ```
 
-`useContext` returns the <CodeStep step={2}>context value</CodeStep> for the <CodeStep step={1}>context</CodeStep> you passed. To determine the context value, React searches the component tree and finds **the closest context provider above** for that particular context.
+`useContext` 針對你傳入的 <CodeStep step={1}>context</CodeStep> 回傳 <CodeStep step={2}>context 值</CodeStep>。為了決定 context 值，React 搜尋元件樹，並尋找針對這個 context，**上方距離最近的 context provider**。
 
-To pass context to a `Button`, wrap it or one of its parent components into the corresponding context provider:
+要傳入 context 給 `Button` 的話，在它或其中一個父元件外，包上一層對應的 context provider：
 
 ```js [[1, 3, "ThemeContext"], [2, 3, "\\"dark\\""], [1, 5, "ThemeContext"]]
 function MyPage() {
@@ -77,15 +76,15 @@ function MyPage() {
 }
 
 function Form() {
-  // ... renders buttons inside ...
+  // ⋯⋯在這之中渲染按鈕⋯⋯
 }
 ```
 
-It doesn't matter how many layers of components there are between the provider and the `Button`. When a `Button` *anywhere* inside of `Form` calls `useContext(ThemeContext)`, it will receive `"dark"` as the value.
+Provider 和 `Button` 之間有幾層元件並不重要。當在 `Form` 以內不管在哪裡的 `Button` 呼叫 `useContext(ThemeContext)`，就會收到 `"dark"` 作為 context 的值。
 
 <Pitfall>
 
-`useContext()` always looks for the closest provider *above* the component that calls it. It searches upwards and **does not** consider providers in the component from which you're calling `useContext()`.
+`useContext()` 必定尋找呼叫元件 *上方* 最近的 provider。它只會往上搜尋，**不會考慮** 你從 provider 下的哪一個元件呼叫 `useContext()`。
 
 </Pitfall>
 
@@ -106,9 +105,9 @@ export default function MyApp() {
 
 function Form() {
   return (
-    <Panel title="Welcome">
-      <Button>Sign up</Button>
-      <Button>Log in</Button>
+    <Panel title="歡迎">
+      <Button>註冊</Button>
+      <Button>登入</Button>
     </Panel>
   );
 }
@@ -175,9 +174,9 @@ function Button({ children }) {
 
 ---
 
-### Updating data passed via context {/*updating-data-passed-via-context*/}
+### 以 context 更新傳遞的資料 {/*updating-data-passed-via-context*/}
 
-Often, you'll want the context to change over time. To update context, combine it with [state.](/reference/react/useState) Declare a state variable in the parent component, and pass the current state down as the <CodeStep step={2}>context value</CodeStep> to the provider.
+通常，你會希望 context 隨著時間變化。要更新 context 的話，搭配使用 context 和 [state](/reference/react/useState)。在父元件宣告一個狀態變數，並將當前狀態作為 <CodeStep step={2}>context 的值</CodeStep> 向下傳遞給 provider。
 
 ```js {2} [[1, 4, "ThemeContext"], [2, 4, "theme"], [1, 11, "ThemeContext"]]
 function MyPage() {
@@ -188,20 +187,20 @@ function MyPage() {
       <Button onClick={() => {
         setTheme('light');
       }}>
-        Switch to light theme
+        切換到 light 主題
       </Button>
     </ThemeContext>
   );
 }
 ```
 
-Now any `Button` inside of the provider will receive the current `theme` value. If you call `setTheme` to update the `theme` value that you pass to the provider, all `Button` components will re-render with the new `'light'` value.
+現在 provider 中的任何 `Button` 都會收到當前的 `theme` 的值。如果呼叫 `setTheme` 來更新你傳給 provider 的 `theme` 值，所有的 `Button` 元件都會以新的 `'light'` 值，重新渲染。
 
-<Recipes titleText="Examples of updating context" titleId="examples-basic">
+<Recipes titleText="更新 context 的範例" titleId="examples-basic">
 
-#### Updating a value via context {/*updating-a-value-via-context*/}
+#### 以 context 更新數值 {/*updating-a-value-via-context*/}
 
-In this example, the `MyApp` component holds a state variable which is then passed to the `ThemeContext` provider. Checking the "Dark mode" checkbox updates the state. Changing the provided value re-renders all the components using that context.
+在這個範例中，`MyApp` 元件有一個在稍候會傳給 `ThemeContext` provider 的狀態變數。試著改變「Dark 模式」核取方塊來更新狀態。改變提供的值，會讓所有使用這個 context 的元件重新渲染。
 
 <Sandpack>
 
@@ -223,7 +222,7 @@ export default function MyApp() {
             setTheme(e.target.checked ? 'dark' : 'light')
           }}
         />
-        Use dark mode
+        使用 dark 模式
       </label>
     </ThemeContext>
   )
@@ -231,9 +230,9 @@ export default function MyApp() {
 
 function Form({ children }) {
   return (
-    <Panel title="Welcome">
-      <Button>Sign up</Button>
-      <Button>Log in</Button>
+    <Panel title="歡迎">
+      <Button>註冊</Button>
+      <Button>登入</Button>
     </Panel>
   );
 }
@@ -299,13 +298,13 @@ function Button({ children }) {
 
 </Sandpack>
 
-Note that `value="dark"` passes the `"dark"` string, but `value={theme}` passes the value of the JavaScript `theme` variable with [JSX curly braces.](/learn/javascript-in-jsx-with-curly-braces) Curly braces also let you pass context values that aren't strings.
+現在 `value="dark"` 傳入 `"dark"` 字串，但 `value={theme}` 是以 [JSX 花括號（curly brace）](/learn/javascript-in-jsx-with-curly-braces) 傳入 JavaScript 的 `theme` 變數。花括號可以讓你傳入非字串的 context 值。
 
 <Solution />
 
-#### Updating an object via context {/*updating-an-object-via-context*/}
+#### 以 context 更新物件 {/*updating-an-object-via-context*/}
 
-In this example, there is a `currentUser` state variable which holds an object. You combine `{ currentUser, setCurrentUser }` into a single object and pass it down through the context inside the `value={}`. This lets any component below, such as `LoginButton`, read both `currentUser` and `setCurrentUser`, and then call `setCurrentUser` when needed.
+在這個範例中，`currentUser` 狀態變數中有一個物件。你把 `{ currentUser, setCurrentUser }` 組合成單一個物件，並在 `value={}` 中向下傳遞。這會讓下方像是 `LoginButton` 這樣的任何一個元件，同時讀取 `currentUser` 和 `setCurrentUser`，並在需要的時候呼叫 `setCurrentUser`。
 
 <Sandpack>
 
@@ -330,7 +329,7 @@ export default function MyApp() {
 
 function Form({ children }) {
   return (
-    <Panel title="Welcome">
+    <Panel title="歡迎">
       <LoginButton />
     </Panel>
   );
@@ -343,13 +342,13 @@ function LoginButton() {
   } = useContext(CurrentUserContext);
 
   if (currentUser !== null) {
-    return <p>You logged in as {currentUser.name}.</p>;
+    return <p>你已登入為 {currentUser.name} 。</p>;
   }
 
   return (
     <Button onClick={() => {
       setCurrentUser({ name: 'Advika' })
-    }}>Log in as Advika</Button>
+    }}>以 Advika 登入</Button>
   );
 }
 
@@ -395,9 +394,9 @@ label {
 
 <Solution />
 
-#### Multiple contexts {/*multiple-contexts*/}
+#### 多個 contexts {/*multiple-contexts*/}
 
-In this example, there are two independent contexts. `ThemeContext` provides the current theme, which is a string, while `CurrentUserContext` holds the object representing the current user.
+在這個範例中，有兩個相互獨立的 context。`ThemeContext` 提供當前的主題，為字串；而 `CurrentUserContext` 中是一個代表目前使用者的物件。
 
 <Sandpack>
 
@@ -427,7 +426,7 @@ export default function MyApp() {
               setTheme(e.target.checked ? 'dark' : 'light')
             }}
           />
-          Use dark mode
+          使用 dark 模式
         </label>
       </CurrentUserContext>
     </ThemeContext>
@@ -437,7 +436,7 @@ export default function MyApp() {
 function WelcomePanel({ children }) {
   const {currentUser} = useContext(CurrentUserContext);
   return (
-    <Panel title="Welcome">
+    <Panel title="歡迎">
       {currentUser !== null ?
         <Greeting /> :
         <LoginForm />
@@ -449,7 +448,7 @@ function WelcomePanel({ children }) {
 function Greeting() {
   const {currentUser} = useContext(CurrentUserContext);
   return (
-    <p>You logged in as {currentUser.name}.</p>
+    <p>你已登入為 {currentUser.name} 。</p>
   )
 }
 
@@ -461,7 +460,7 @@ function LoginForm() {
   return (
     <>
       <label>
-        First name{': '}
+        名字{'：'}
         <input
           required
           value={firstName}
@@ -469,7 +468,7 @@ function LoginForm() {
         />
       </label>
       <label>
-        Last name{': '}
+        姓氏{'：'}
         <input
         required
           value={lastName}
@@ -486,7 +485,7 @@ function LoginForm() {
       >
         Log in
       </Button>
-      {!canLogin && <i>Fill in both fields.</i>}
+      {!canLogin && <i>兩個欄位均須填寫。</i>}
     </>
   );
 }
@@ -562,9 +561,9 @@ label {
 
 <Solution />
 
-#### Extracting providers to a component {/*extracting-providers-to-a-component*/}
+#### 將 provider 抽成元件 {/*extracting-providers-to-a-component*/}
 
-As your app grows, it is expected that you'll have a "pyramid" of contexts closer to the root of your app. There is nothing wrong with that. However, if you dislike the nesting aesthetically, you can extract the providers into a single component. In this example, `MyProviders` hides the "plumbing" and renders the children passed to it inside the necessary providers. Note that the `theme` and `setTheme` state is needed in `MyApp` itself, so `MyApp` still owns that piece of the state.
+隨著應用程式成長，在應用程式的根部（root）附近，會形成一座由 context 組成的「金字塔」。這沒什麼問題。不過，如果你在美感上不喜歡這種嵌套結構，可以將 provider 抽成單一的元件。在這個範例中，`MyProviders` 藏起「管線（plumbing）」，並以必要的 provider 渲染傳入的子元件。注意 `theme` 和 `setTheme` 狀態是 `MyApp` 本身必須的，所以 `MyApp` 仍然擁有部分的狀態。
 
 <Sandpack>
 
@@ -587,7 +586,7 @@ export default function MyApp() {
             setTheme(e.target.checked ? 'dark' : 'light')
           }}
         />
-        Use dark mode
+        使用 dark 模式
       </label>
     </MyProviders>
   );
@@ -612,7 +611,7 @@ function MyProviders({ children, theme, setTheme }) {
 function WelcomePanel({ children }) {
   const {currentUser} = useContext(CurrentUserContext);
   return (
-    <Panel title="Welcome">
+    <Panel title="歡迎">
       {currentUser !== null ?
         <Greeting /> :
         <LoginForm />
@@ -624,7 +623,7 @@ function WelcomePanel({ children }) {
 function Greeting() {
   const {currentUser} = useContext(CurrentUserContext);
   return (
-    <p>You logged in as {currentUser.name}.</p>
+    <p>你已登入為 {currentUser.name} 。</p>
   )
 }
 
@@ -636,7 +635,7 @@ function LoginForm() {
   return (
     <>
       <label>
-        First name{': '}
+        名字{': '}
         <input
           required
           value={firstName}
@@ -644,7 +643,7 @@ function LoginForm() {
         />
       </label>
       <label>
-        Last name{': '}
+        姓氏{'：'}
         <input
         required
           value={lastName}
@@ -661,7 +660,7 @@ function LoginForm() {
       >
         Log in
       </Button>
-      {!canLogin && <i>Fill in both fields.</i>}
+      {!canLogin && <i>兩個欄位均須填寫。</i>}
     </>
   );
 }
@@ -737,11 +736,11 @@ label {
 
 <Solution />
 
-#### Scaling up with context and a reducer {/*scaling-up-with-context-and-a-reducer*/}
+#### 使用 reducer 和 context 擴充應用程式 {/*scaling-up-with-context-and-a-reducer*/}
 
-In larger apps, it is common to combine context with a [reducer](/reference/react/useReducer) to extract the logic related to some state out of components. In this example, all the "wiring" is hidden in the `TasksContext.js`, which contains a reducer and two separate contexts.
+在大型應用程式中，常常會搭配使用 context 和 [reducer](/reference/react/useReducer) ，將某些與狀態相關的邏輯抽到元件外。在這個範例中，所有的「串接（wiring）」都被藏進 `TasksContext.js`，包含一個 reducer 和兩個分別的 contexts。
 
-Read a [full walkthrough](/learn/scaling-up-with-reducer-and-context) of this example.
+閱讀這個範例的[完整演練](/learn/scaling-up-with-reducer-and-context)。
 
 <Sandpack>
 
@@ -753,7 +752,7 @@ import { TasksProvider } from './TasksContext.js';
 export default function TaskApp() {
   return (
     <TasksProvider>
-      <h1>Day off in Kyoto</h1>
+      <h1>放假去京都</h1>
       <AddTask />
       <TaskList />
     </TasksProvider>
@@ -813,15 +812,15 @@ function tasksReducer(tasks, action) {
       return tasks.filter(t => t.id !== action.id);
     }
     default: {
-      throw Error('Unknown action: ' + action.type);
+      throw Error('未知的 action：' + action.type);
     }
   }
 }
 
 const initialTasks = [
-  { id: 0, text: 'Philosopher’s Path', done: true },
-  { id: 1, text: 'Visit the temple', done: false },
-  { id: 2, text: 'Drink matcha', done: false }
+  { id: 0, text: '哲學之道', done: true },
+  { id: 1, text: '參觀寺廟', done: false },
+  { id: 2, text: '喝抹茶', done: false }
 ];
 ```
 
@@ -835,7 +834,7 @@ export default function AddTask() {
   return (
     <>
       <input
-        placeholder="Add task"
+        placeholder="新增任務"
         value={text}
         onChange={e => setText(e.target.value)}
       />
@@ -846,7 +845,7 @@ export default function AddTask() {
           id: nextId++,
           text: text,
         }); 
-      }}>Add</button>
+      }}>新增</button>
     </>
   );
 }
@@ -890,7 +889,7 @@ function Task({ task }) {
             });
           }} />
         <button onClick={() => setIsEditing(false)}>
-          Save
+          儲存
         </button>
       </>
     );
@@ -899,7 +898,7 @@ function Task({ task }) {
       <>
         {task.text}
         <button onClick={() => setIsEditing(true)}>
-          Edit
+          編輯
         </button>
       </>
     );
@@ -926,7 +925,7 @@ function Task({ task }) {
           id: task.id
         });
       }}>
-        Delete
+        刪除
       </button>
     </label>
   );
@@ -947,25 +946,25 @@ ul, li { margin: 0; padding: 0; }
 
 ---
 
-### Specifying a fallback default value {/*specifying-a-fallback-default-value*/}
+### 指定備用預設值 {/*specifying-a-fallback-default-value*/}
 
-If React can't find any providers of that particular <CodeStep step={1}>context</CodeStep> in the parent tree, the context value returned by `useContext()` will be equal to the <CodeStep step={3}>default value</CodeStep> that you specified when you [created that context](/reference/react/createContext):
+如果 React 在父元件樹中，找不到任何特定 <CodeStep step={1}>context</CodeStep> 的 provider，`useContext()` 所回傳的 context 值就會和你[創建 context](/reference/react/createContext) 時指定的預設值相同：
 
 ```js [[1, 1, "ThemeContext"], [3, 1, "null"]]
 const ThemeContext = createContext(null);
 ```
 
-The default value **never changes**. If you want to update context, use it with state as [described above.](#updating-data-passed-via-context)
+這個預設值 **不會改變**。如果想更新 context，像[本文上面所說的](#updating-data-passed-via-context)搭配狀態來使用。
 
-Often, instead of `null`, there is some more meaningful value you can use as a default, for example:
+通常，除了 `null`，有更多可以作為預設，且更有意義的值，例如：
 
 ```js [[1, 1, "ThemeContext"], [3, 1, "light"]]
 const ThemeContext = createContext('light');
 ```
 
-This way, if you accidentally render some component without a corresponding provider, it won't break. This also helps your components work well in a test environment without setting up a lot of providers in the tests.
+用這個方式，如果不小心在沒有對應 provider 的情況下渲染元件，也不會壞掉。這也能幫助元件在測試環境順利運作，而不用在測試中設定很多 providers。
 
-In the example below, the "Toggle theme" button is always light because it's **outside any theme context provider** and the default context theme value is `'light'`. Try editing the default theme to be `'dark'`.
+下面的範例中，「切換主題」按鈕總是 light，因為它在 **任何 theme context provider 之外**，而且主題的預設值是 `'light'`。試著把預設主題更改為 `'dark'`。
 
 <Sandpack>
 
@@ -984,7 +983,7 @@ export default function MyApp() {
       <Button onClick={() => {
         setTheme(theme === 'dark' ? 'light' : 'dark');
       }}>
-        Toggle theme
+        切換主題
       </Button>
     </>
   )
@@ -992,9 +991,9 @@ export default function MyApp() {
 
 function Form({ children }) {
   return (
-    <Panel title="Welcome">
-      <Button>Sign up</Button>
-      <Button>Log in</Button>
+    <Panel title="歡迎">
+      <Button>註冊</Button>
+      <Button>登入</Button>
     </Panel>
   );
 }
@@ -1062,9 +1061,9 @@ function Button({ children, onClick }) {
 
 ---
 
-### Overriding context for a part of the tree {/*overriding-context-for-a-part-of-the-tree*/}
+### 在元件樹的某些部分覆寫 context {/*overriding-context-for-a-part-of-the-tree*/}
 
-You can override the context for a part of the tree by wrapping that part in a provider with a different value.
+你可以在元件樹的某些部分覆寫（override） context，以不同的值包裹 provider 中的某些部分。
 
 ```js {3,5}
 <ThemeContext value="dark">
@@ -1076,13 +1075,13 @@ You can override the context for a part of the tree by wrapping that part in a p
 </ThemeContext>
 ```
 
-You can nest and override providers as many times as you need.
+你可以依照需求多次嵌套（nest）並覆寫 provider。
 
-<Recipes titleText="Examples of overriding context">
+<Recipes titleText="覆寫 context 的範例">
 
-#### Overriding a theme {/*overriding-a-theme*/}
+#### 覆寫主題 {/*overriding-a-theme*/}
 
-Here, the button *inside* the `Footer` receives a different context value (`"light"`) than the buttons outside (`"dark"`).
+`Footer` *中* 的按鈕接收的 context 值（`"light"`），不同於 `Footer` 外的按鈕（`"dark"`）。
 
 <Sandpack>
 
@@ -1101,9 +1100,9 @@ export default function MyApp() {
 
 function Form() {
   return (
-    <Panel title="Welcome">
-      <Button>Sign up</Button>
-      <Button>Log in</Button>
+    <Panel title="歡迎">
+      <Button>註冊</Button>
+      <Button>登入</Button>
       <ThemeContext value="light">
         <Footer />
       </ThemeContext>
@@ -1114,7 +1113,7 @@ function Form() {
 function Footer() {
   return (
     <footer>
-      <Button>Settings</Button>
+      <Button>設置</Button>
     </footer>
   );
 }
@@ -1186,11 +1185,11 @@ footer {
 
 <Solution />
 
-#### Automatically nested headings {/*automatically-nested-headings*/}
+#### 自動嵌套的標頭 {/*automatically-nested-headings*/}
 
-You can "accumulate" information when you nest context providers. In this example, the `Section` component keeps track of the `LevelContext` which specifies the depth of the section nesting. It reads the `LevelContext` from the parent section, and provides the `LevelContext` number increased by one to its children. As a result, the `Heading` component can automatically decide which of the `<h1>`, `<h2>`, `<h3>`, ..., tags to use based on how many `Section` components it is nested inside of.
+當嵌套 context provider 時，你可以「累積」資訊。在這個範例中，`Section` 元件指定章節（section）嵌套的深度，以保持追蹤 `LevelContext`。它從父章節讀取 `LevelContext`，並提供由各個章節增加的 `LevelContext` 值給子元件。因此，`Heading` 元件可以自動根據 `Section` 嵌套的數量，來決定要用 `<h1>`、`<h2>`、`<h3>`⋯⋯
 
-Read a [detailed walkthrough](/learn/passing-data-deeply-with-context) of this example.
+閱讀更多這個範例的[演練細節](/learn/passing-data-deeply-with-context)。
 
 <Sandpack>
 
@@ -1201,19 +1200,19 @@ import Section from './Section.js';
 export default function Page() {
   return (
     <Section>
-      <Heading>Title</Heading>
+      <Heading>標題</Heading>
       <Section>
-        <Heading>Heading</Heading>
-        <Heading>Heading</Heading>
-        <Heading>Heading</Heading>
+        <Heading>標頭</Heading>
+        <Heading>標頭</Heading>
+        <Heading>標頭</Heading>
         <Section>
-          <Heading>Sub-heading</Heading>
-          <Heading>Sub-heading</Heading>
-          <Heading>Sub-heading</Heading>
+          <Heading>小標頭</Heading>
+          <Heading>小標頭</Heading>
+          <Heading>小標頭</Heading>
           <Section>
-            <Heading>Sub-sub-heading</Heading>
-            <Heading>Sub-sub-heading</Heading>
-            <Heading>Sub-sub-heading</Heading>
+            <Heading>小小標頭</Heading>
+            <Heading>小小標頭</Heading>
+            <Heading>小小標頭</Heading>
           </Section>
         </Section>
       </Section>
@@ -1246,7 +1245,7 @@ export default function Heading({ children }) {
   const level = useContext(LevelContext);
   switch (level) {
     case 0:
-      throw Error('Heading must be inside a Section!');
+      throw Error('標頭必須在章節中！');
     case 1:
       return <h1>{children}</h1>;
     case 2:
@@ -1260,7 +1259,7 @@ export default function Heading({ children }) {
     case 6:
       return <h6>{children}</h6>;
     default:
-      throw Error('Unknown level: ' + level);
+      throw Error('未知的 level：' + level);
   }
 }
 ```
@@ -1288,9 +1287,9 @@ export const LevelContext = createContext(0);
 
 ---
 
-### Optimizing re-renders when passing objects and functions {/*optimizing-re-renders-when-passing-objects-and-functions*/}
+### 最佳化傳入物件和函式時的重新渲染 {/*optimizing-re-renders-when-passing-objects-and-functions*/}
 
-You can pass any values via context, including objects and functions.
+你可以用 context 傳入任何值，包含物件和函式。
 
 ```js [[2, 10, "{ currentUser, login }"]] 
 function MyApp() {
@@ -1309,9 +1308,9 @@ function MyApp() {
 }
 ```
 
-Here, the <CodeStep step={2}>context value</CodeStep> is a JavaScript object with two properties, one of which is a function. Whenever `MyApp` re-renders (for example, on a route update), this will be a *different* object pointing at a *different* function, so React will also have to re-render all components deep in the tree that call `useContext(AuthContext)`.
+<CodeStep step={2}>Context 值</CodeStep>是有兩個屬性（properties）的 JavaScript 物件，其中一個屬性是函式。無論 `MyApp` 什麼時候重新渲染（例如，當路由更新時），都會是一個 *不同的* 物件指向 *不同的* 函式，所以 React 也必須重新渲染元件樹中，所有呼叫 `useContext(AuthContext)` 的元件。
 
-In smaller apps, this is not a problem. However, there is no need to re-render them if the underlying data, like `currentUser`, has not changed. To help React take advantage of that fact, you may wrap the `login` function with [`useCallback`](/reference/react/useCallback) and wrap the object creation into [`useMemo`](/reference/react/useMemo). This is a performance optimization:
+在小型應用程式中，這不算什麼問題。但是，如果像是 `currentUser` 這樣的底層資料沒有改變，其實沒必要重新渲染。為了幫助 React 發揮長處，你可以用 [`useCallback`](/reference/react/useCallback) 包裹函式，並用 [`useMemo`](/reference/react/useMemo) 包裹物件。這是效能最佳化的方式：
 
 ```js {6,9,11,14,17}
 import { useCallback, useMemo } from 'react';
@@ -1337,51 +1336,51 @@ function MyApp() {
 }
 ```
 
-As a result of this change, even if `MyApp` needs to re-render, the components calling `useContext(AuthContext)` won't need to re-render unless `currentUser` has changed.
+修改的結果是，即使 `MyApp` 需要重新渲染，呼叫 `useContext(AuthContext)` 的元件也不需要重新渲染，除非 `currentUser` 有變化。
 
-Read more about [`useMemo`](/reference/react/useMemo#skipping-re-rendering-of-components) and [`useCallback`.](/reference/react/useCallback#skipping-re-rendering-of-components)
+閱讀更多有關 [`useMemo`](/reference/react/useMemo#skipping-re-rendering-of-components) 和 [`useCallback`.](/reference/react/useCallback#skipping-re-rendering-of-components)。
 
 ---
 
-## Troubleshooting {/*troubleshooting*/}
+## 故障排除 {/*troubleshooting*/}
 
-### My component doesn't see the value from my provider {/*my-component-doesnt-see-the-value-from-my-provider*/}
+### 元件找不到 provider 的值 {/*my-component-doesnt-see-the-value-from-my-provider*/}
 
-There are a few common ways that this can happen:
+有一些常見的方式會導致這個狀況發生：
 
-1. You're rendering `<SomeContext>` in the same component (or below) as where you're calling `useContext()`. Move `<SomeContext>` *above and outside* the component calling `useContext()`.
-2. You may have forgotten to wrap your component with `<SomeContext>`, or you might have put it in a different part of the tree than you thought. Check whether the hierarchy is right using [React DevTools.](/learn/react-developer-tools)
-3. You might be running into some build issue with your tooling that causes `SomeContext` as seen from the providing component and `SomeContext` as seen by the reading component to be two different objects. This can happen if you use symlinks, for example. You can verify this by assigning them to globals like `window.SomeContext1` and `window.SomeContext2` and then checking whether `window.SomeContext1 === window.SomeContext2` in the console. If they're not the same, fix that issue on the build tool level.
+1. 你在呼叫 `useContext()` 的同一個元件中（或底下）渲染 `<SomeContext>`。將 `<SomeContext>` 移到呼叫 `useContext()` 的元件上面。
+2. 你可能忘記在元件外包一層 `<SomeContext>`，或你把它放在元件樹的不同部分。用 [React 開發者工具](/learn/react-developer-tools)檢查階層是否正確。
+3. 你可能遇到一些建置工具的問題，導致 `SomeContext` 被讀取的元件視為不同的物件。舉例來說，這可能會發生在使用符號連結時。你可以把 context 賦值給全域變數來檢查，像是 `window.SomeContext1` 和 `window.SomeContext2`，接著在 console 裡檢查 `window.SomeContext1 === window.SomeContext2`。如果兩者不同，必須在建置工具的層級下解決這個問題。
 
-### I am always getting `undefined` from my context although the default value is different {/*i-am-always-getting-undefined-from-my-context-although-the-default-value-is-different*/}
+### 我總是從 context 取得 `undefined`，即使預設值並不是 `undefined` {/*i-am-always-getting-undefined-from-my-context-although-the-default-value-is-different*/}
 
-You might have a provider without a `value` in the tree:
+你的元件樹中的 provider 可能沒有 `value`：
 
 ```js {1,2}
-// 🚩 Doesn't work: no value prop
+// 🚩 無法運作：沒有 value prop
 <ThemeContext>
    <Button />
 </ThemeContext>
 ```
 
-If you forget to specify `value`, it's like passing `value={undefined}`.
+如果忘記指定 `value`，就會像是傳入 `value={undefined}`。
 
-You may have also mistakingly used a different prop name by mistake:
+你可能誤用了不同的 prop 名稱：
 
 ```js {1,2}
-// 🚩 Doesn't work: prop should be called "value"
+// 🚩 無法運作：prop 的名稱應該是「value」
 <ThemeContext theme={theme}>
    <Button />
 </ThemeContext>
 ```
 
-In both of these cases you should see a warning from React in the console. To fix them, call the prop `value`:
+上述這兩個情形，都應該會在 console 看到 React 的警告。要修正的話，稱 prop 為 `value`：
 
 ```js {1,2}
-// ✅ Passing the value prop
+// ✅ 將資料傳入 value prop
 <ThemeContext value={theme}>
    <Button />
 </ThemeContext>
 ```
 
-Note that the [default value from your `createContext(defaultValue)` call](#specifying-a-fallback-default-value) is only used **if there is no matching provider above at all.** If there is a `<SomeContext value={undefined}>` component somewhere in the parent tree, the component calling `useContext(SomeContext)` *will* receive `undefined` as the context value.
+注意[`createContext(defaultValue)` 呼叫的預設值](#specifying-a-fallback-default-value)只會在 **上方完全沒有對應的 provider 時** 被用到。如果父元件樹的某個地方有 `<SomeContext value={undefined}>` 元件，呼叫 `useContext(SomeContext)` 會收到 `undefined` 作為 context 值。


### PR DESCRIPTION
This PR translates the “Hooks – useContext” page into Traditional Chinese.

Related to https://github.com/reactjs/zh-hant.react.dev/issues/260.

Please let me know if anything should be modified. Thank you!

Below is the glossary I followed while translating this page:

|Original|Translation|
|-|-|
|component|元件|
|subscribe|訂閱|
|Context|Context|
|Hook|Hook|
|create|創建|
|tree|元件樹|
|re-render|重新渲染|
|symlink|符號連結|
|context provider|context provider|
|parent component|父元件|
|curly brace|花括弧|
|root|根/根部|
|plumbing|管線|
|reducer|reducer|
|wiring|串接|
|nest|嵌套|
|section|章節|
|heading|標頭|
|property|屬性|
|prop(s)|prop(s)|